### PR TITLE
fix: R2-R5 review — error handling, validation, graceful shutdown

### DIFF
--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -73,17 +73,22 @@ func run() error {
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
-	done := make(chan os.Signal, 1)
-	signal.Notify(done, os.Interrupt, syscall.SIGTERM)
-
+	errCh := make(chan error, 1)
 	go func() {
 		log.Printf("server listening on :%s", cfg.Port)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("listen: %v", err)
+			errCh <- fmt.Errorf("listen: %w", err)
 		}
 	}()
 
-	<-done
+	done := make(chan os.Signal, 1)
+	signal.Notify(done, os.Interrupt, syscall.SIGTERM)
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-done:
+	}
 	log.Println("shutting down...")
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/api/internal/handler/chat_handler.go
+++ b/api/internal/handler/chat_handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/akaitigo/kotowaza-bridge/api/internal/service"
@@ -30,7 +31,14 @@ func (h *ChatHandler) Chat(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := h.svc.Chat(r.Context(), req)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "chat failed")
+		switch {
+		case errors.Is(err, service.ErrValidation):
+			writeError(w, http.StatusBadRequest, err.Error())
+		case errors.Is(err, service.ErrNotFound):
+			writeError(w, http.StatusNotFound, err.Error())
+		default:
+			writeError(w, http.StatusInternalServerError, "chat failed")
+		}
 		return
 	}
 

--- a/api/internal/handler/chat_handler_test.go
+++ b/api/internal/handler/chat_handler_test.go
@@ -88,7 +88,7 @@ func TestChatHandler_Chat(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
 
-	t.Run("returns 500 when kotowaza not found", func(t *testing.T) {
+	t.Run("returns 404 when kotowaza not found", func(t *testing.T) {
 		mockRepo := &repository.MockKotowazaRepository{
 			GetByIDFn: func(_ context.Context, _ uuid.UUID) (*kotowaza.Kotowaza, error) {
 				return nil, nil
@@ -107,6 +107,24 @@ func TestChatHandler_Chat(t *testing.T) {
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)
 
-		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("returns 400 for validation error", func(t *testing.T) {
+		mockRepo := &repository.MockKotowazaRepository{}
+		llm := &testLLMClient{}
+
+		r := setupChatHandler(mockRepo, llm)
+
+		body, _ := json.Marshal(service.ChatRequest{
+			KotowazaID: uuid.New(),
+			Messages:   []service.ChatMessage{},
+		})
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/chat", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
 }

--- a/api/internal/service/chat_service.go
+++ b/api/internal/service/chat_service.go
@@ -2,12 +2,19 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/akaitigo/kotowaza-bridge/api/internal/domain/kotowaza"
 	"github.com/akaitigo/kotowaza-bridge/api/internal/repository"
 	"github.com/google/uuid"
 )
+
+// ErrValidation indicates a client input validation error.
+var ErrValidation = errors.New("validation error")
+
+// ErrNotFound indicates a resource was not found.
+var ErrNotFound = errors.New("not found")
 
 // ChatMessage represents a single chat message.
 type ChatMessage struct {
@@ -52,17 +59,17 @@ var validRoles = map[string]bool{"user": true, "assistant": true}
 // Chat sends a chat message and returns the LLM response.
 func (s *ChatService) Chat(ctx context.Context, req ChatRequest) (*ChatResponse, error) {
 	if len(req.Messages) == 0 {
-		return nil, fmt.Errorf("messages must not be empty")
+		return nil, fmt.Errorf("%w: messages must not be empty", ErrValidation)
 	}
 	if len(req.Messages) > maxMessages {
-		return nil, fmt.Errorf("too many messages (max %d)", maxMessages)
+		return nil, fmt.Errorf("%w: too many messages (max %d)", ErrValidation, maxMessages)
 	}
 	for _, m := range req.Messages {
 		if !validRoles[m.Role] {
-			return nil, fmt.Errorf("invalid role: %s", m.Role)
+			return nil, fmt.Errorf("%w: invalid role: %s", ErrValidation, m.Role)
 		}
 		if len(m.Content) > maxMessageLength {
-			return nil, fmt.Errorf("message too long (max %d characters)", maxMessageLength)
+			return nil, fmt.Errorf("%w: message too long (max %d characters)", ErrValidation, maxMessageLength)
 		}
 	}
 
@@ -71,7 +78,7 @@ func (s *ChatService) Chat(ctx context.Context, req ChatRequest) (*ChatResponse,
 		return nil, fmt.Errorf("get kotowaza for chat: %w", err)
 	}
 	if k == nil {
-		return nil, fmt.Errorf("kotowaza not found: %s", req.KotowazaID)
+		return nil, fmt.Errorf("%w: kotowaza %s", ErrNotFound, req.KotowazaID)
 	}
 
 	systemPrompt := buildSystemPrompt(k)

--- a/api/internal/service/chat_service_test.go
+++ b/api/internal/service/chat_service_test.go
@@ -116,6 +116,56 @@ func TestChatService_Chat(t *testing.T) {
 	})
 }
 
+func TestChatService_Validation(t *testing.T) {
+	mockRepo := &repository.MockKotowazaRepository{}
+	mockLLM := &mockLLMClient{}
+	svc := NewChatService(mockRepo, mockLLM)
+
+	t.Run("rejects empty messages", func(t *testing.T) {
+		_, err := svc.Chat(context.Background(), ChatRequest{
+			KotowazaID: uuid.New(),
+			Messages:   []ChatMessage{},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must not be empty")
+	})
+
+	t.Run("rejects too many messages", func(t *testing.T) {
+		msgs := make([]ChatMessage, 51)
+		for i := range msgs {
+			msgs[i] = ChatMessage{Role: "user", Content: "test"}
+		}
+		_, err := svc.Chat(context.Background(), ChatRequest{
+			KotowazaID: uuid.New(),
+			Messages:   msgs,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "too many messages")
+	})
+
+	t.Run("rejects invalid role", func(t *testing.T) {
+		_, err := svc.Chat(context.Background(), ChatRequest{
+			KotowazaID: uuid.New(),
+			Messages:   []ChatMessage{{Role: "system", Content: "hack"}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid role")
+	})
+
+	t.Run("rejects message too long", func(t *testing.T) {
+		longMsg := make([]byte, 2001)
+		for i := range longMsg {
+			longMsg[i] = 'a'
+		}
+		_, err := svc.Chat(context.Background(), ChatRequest{
+			KotowazaID: uuid.New(),
+			Messages:   []ChatMessage{{Role: "user", Content: string(longMsg)}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "message too long")
+	})
+}
+
 func TestBuildSystemPrompt(t *testing.T) {
 	k := &kotowaza.Kotowaza{
 		Japanese:     "猿も木から落ちる",


### PR DESCRIPTION
## Summary
- R2: ChatService validation tests (empty/count/role/length) — 4 new test cases
- R2: HTTP status differentiation (400/404/500) via sentinel errors
- R3: ErrValidation, ErrNotFound for clean error classification
- R5: Fix goroutine leak — errCh pattern replaces log.Fatalf in goroutine

## Test plan
- [x] `go test -race ./...` passes (including new validation tests)
- [x] `go build ./cmd/server` succeeds
- [x] Web build clean