### PR TITLE
fix: CORS許可リスト・入力検証・タイムアウト・ヘルスチェックの堅牢化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 DATABASE_URL=postgres://user:password@localhost:5432/kotowaza_bridge?sslmode=disable
 LLM_API_KEY=your-api-key-here
 LLM_MODEL=claude-sonnet-4-20250514
-CORS_ORIGIN=http://localhost:3000
+# Comma-separated allowlist of origins permitted for cross-origin requests.
+# Defaults to http://localhost:3000 when unset; set explicitly in production.
+CORS_ALLOWED_ORIGINS=http://localhost:3000
 PORT=8080

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ kotowaza-bridge/
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/v1/health` | ヘルスチェック |
+| GET | `/api/v1/health` | Liveness（プロセス稼働確認、依存先に触れない） |
+| GET | `/api/v1/health/ready` | Readiness（DB接続を検証。障害時は503） |
 | GET | `/api/v1/kotowaza` | ことわざ一覧 |
 | GET | `/api/v1/kotowaza/:id` | ことわざ詳細 |
 | GET | `/api/v1/kotowaza/search?q=` | キーワード検索 |

--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -54,27 +54,36 @@ func run() error {
 	chatSvc := service.NewChatService(repo, llmClient)
 	chatH := handler.NewChatHandler(chatSvc)
 
+	healthH := handler.NewHealthHandler(pool)
+
 	r := chi.NewRouter()
 	r.Use(chimw.Logger)
 	r.Use(chimw.Recoverer)
 	r.Use(chimw.RequestID)
-	r.Use(middleware.CORS(cfg.CORSOrigin))
+	r.Use(middleware.CORS(cfg.CORSAllowedOrigins))
 
 	chatRateLimiter := middleware.NewIPRateLimiter(middleware.DefaultChatRateLimiterConfig())
 	defer chatRateLimiter.Close()
 
 	r.Route("/api/v1", func(r chi.Router) {
-		r.Get("/health", handler.Health)
+		r.Get("/health", healthH.Live)
+		r.Get("/health/ready", healthH.Ready)
 		r.Get("/kotowaza", kotowazaH.List)
 		r.Get("/kotowaza/search", kotowazaH.Search)
 		r.Get("/kotowaza/{id}", kotowazaH.GetByID)
 		r.With(chatRateLimiter.Middleware).Post("/chat", chatH.Chat)
 	})
 
+	// WriteTimeout must exceed the upstream LLM client timeout (60s) so slow but
+	// valid chat responses are not cut off; IdleTimeout bounds keep-alive
+	// connections to avoid file-descriptor exhaustion.
 	srv := &http.Server{
 		Addr:              ":" + cfg.Port,
 		Handler:           r,
 		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      90 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	errCh := make(chan error, 1)

--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -3,16 +3,22 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 // Config holds application configuration.
 type Config struct {
-	Port        string
-	DatabaseURL string
-	LLMAPIKey   string
-	LLMModel    string
-	CORSOrigin  string
+	Port               string
+	DatabaseURL        string
+	LLMAPIKey          string
+	LLMModel           string
+	CORSAllowedOrigins []string
 }
+
+// defaultCORSOrigin is the local development frontend origin used only when
+// CORS_ALLOWED_ORIGINS is not set. Production deployments must set the
+// environment variable explicitly to their real origins.
+const defaultCORSOrigin = "http://localhost:3000"
 
 // Load reads configuration from environment variables.
 func Load() (*Config, error) {
@@ -36,16 +42,27 @@ func Load() (*Config, error) {
 		llmModel = "claude-sonnet-4-20250514"
 	}
 
-	corsOrigin := os.Getenv("CORS_ORIGIN")
-	if corsOrigin == "" {
-		corsOrigin = "http://localhost:3000"
-	}
-
 	return &Config{
-		Port:        port,
-		DatabaseURL: dbURL,
-		LLMAPIKey:   llmKey,
-		LLMModel:    llmModel,
-		CORSOrigin:  corsOrigin,
+		Port:               port,
+		DatabaseURL:        dbURL,
+		LLMAPIKey:          llmKey,
+		LLMModel:           llmModel,
+		CORSAllowedOrigins: parseCORSOrigins(os.Getenv("CORS_ALLOWED_ORIGINS")),
 	}, nil
+}
+
+// parseCORSOrigins splits a comma-separated origin list, trimming whitespace
+// and dropping empty entries. When no origin is provided it falls back to the
+// local development origin so the app remains usable without configuration.
+func parseCORSOrigins(raw string) []string {
+	var origins []string
+	for _, part := range strings.Split(raw, ",") {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			origins = append(origins, trimmed)
+		}
+	}
+	if len(origins) == 0 {
+		return []string{defaultCORSOrigin}
+	}
+	return origins
 }

--- a/api/internal/handler/health_handler.go
+++ b/api/internal/handler/health_handler.go
@@ -1,13 +1,60 @@
 package handler
 
-import "net/http"
+import (
+	"context"
+	"log"
+	"net/http"
+	"time"
+)
+
+// readinessTimeout bounds the database ping performed by the readiness check so
+// a hung database cannot block the health endpoint indefinitely.
+const readinessTimeout = 2 * time.Second
+
+// Pinger is the subset of the database pool required for readiness checks.
+type Pinger interface {
+	Ping(ctx context.Context) error
+}
+
+// HealthHandler handles liveness and readiness checks.
+type HealthHandler struct {
+	db Pinger
+}
+
+// NewHealthHandler creates a new HealthHandler.
+func NewHealthHandler(db Pinger) *HealthHandler {
+	return &HealthHandler{db: db}
+}
 
 // HealthResponse represents the health check response.
 type HealthResponse struct {
 	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
 }
 
-// Health handles GET /api/v1/health
-func Health(w http.ResponseWriter, _ *http.Request) {
+// Live handles GET /api/v1/health and reports process liveness without
+// touching downstream dependencies. It always returns 200 while the process is
+// running so orchestrators do not restart a healthy process during a transient
+// database outage.
+func (h *HealthHandler) Live(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, HealthResponse{Status: "ok"})
+}
+
+// Ready handles GET /api/v1/health/ready and reports whether the service can
+// serve traffic by verifying database connectivity. It returns 503 when the
+// database is unreachable so load balancers stop routing requests to this
+// instance.
+func (h *HealthHandler) Ready(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), readinessTimeout)
+	defer cancel()
+
+	if err := h.db.Ping(ctx); err != nil {
+		// Log the underlying cause server-side but return a generic message so
+		// the public endpoint does not leak connection details.
+		log.Printf("readiness check failed: database ping: %v", err)
+		writeJSON(w, http.StatusServiceUnavailable, HealthResponse{Status: "unavailable", Error: "database unreachable"})
+		return
+	}
+
 	writeJSON(w, http.StatusOK, HealthResponse{Status: "ok"})
 }

--- a/api/internal/handler/health_handler_test.go
+++ b/api/internal/handler/health_handler_test.go
@@ -1,7 +1,9 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,18 +12,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHealth(t *testing.T) {
-	t.Run("returns 200 with ok status", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)
+type stubPinger struct {
+	err error
+}
+
+func (s stubPinger) Ping(_ context.Context) error {
+	return s.err
+}
+
+func TestHealthHandler_Live(t *testing.T) {
+	h := NewHealthHandler(stubPinger{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)
+	w := httptest.NewRecorder()
+
+	h.Live(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp HealthResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "ok", resp.Status)
+}
+
+func TestHealthHandler_Ready(t *testing.T) {
+	t.Run("returns 200 when the database is reachable", func(t *testing.T) {
+		h := NewHealthHandler(stubPinger{})
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/health/ready", nil)
 		w := httptest.NewRecorder()
 
-		Health(w, req)
+		h.Ready(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
 
 		var resp HealthResponse
-		err := json.Unmarshal(w.Body.Bytes(), &resp)
-		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 		assert.Equal(t, "ok", resp.Status)
+	})
+
+	t.Run("returns 503 without leaking the ping error when the database is unreachable", func(t *testing.T) {
+		h := NewHealthHandler(stubPinger{err: errors.New("dial tcp 10.0.0.1:5432: connection refused")})
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/health/ready", nil)
+		w := httptest.NewRecorder()
+
+		h.Ready(w, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+
+		var resp HealthResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, "unavailable", resp.Status)
+		assert.NotContains(t, resp.Error, "connection refused")
+		assert.NotContains(t, resp.Error, "10.0.0.1")
 	})
 }

--- a/api/internal/middleware/cors.go
+++ b/api/internal/middleware/cors.go
@@ -2,13 +2,27 @@ package middleware
 
 import "net/http"
 
-// CORS returns a middleware that sets CORS headers.
-func CORS(allowedOrigin string) func(http.Handler) http.Handler {
+// CORS returns a middleware that sets CORS headers only for requests whose
+// Origin header matches one of allowedOrigins. Requests from any other origin
+// receive no Access-Control-Allow-Origin header, so browsers block the
+// cross-origin response. The Vary: Origin header is always set so shared caches
+// never reuse a response across origins.
+func CORS(allowedOrigins []string) func(http.Handler) http.Handler {
+	allowed := make(map[string]struct{}, len(allowedOrigins))
+	for _, o := range allowedOrigins {
+		allowed[o] = struct{}{}
+	}
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Access-Control-Allow-Origin", allowedOrigin)
-			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			w.Header().Add("Vary", "Origin")
+
+			origin := r.Header.Get("Origin")
+			if _, ok := allowed[origin]; ok && origin != "" {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			}
 
 			if r.Method == http.MethodOptions {
 				w.WriteHeader(http.StatusNoContent)

--- a/api/internal/middleware/cors_test.go
+++ b/api/internal/middleware/cors_test.go
@@ -1,0 +1,82 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCORS(t *testing.T) {
+	allowed := []string{"https://app.example.com", "http://localhost:3000"}
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := CORS(allowed)(next)
+
+	t.Run("echoes an allowed origin and calls next", func(t *testing.T) {
+		nextCalled = false
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/kotowaza", nil)
+		req.Header.Set("Origin", "https://app.example.com")
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		assert.True(t, nextCalled)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "https://app.example.com", w.Header().Get("Access-Control-Allow-Origin"))
+		assert.Contains(t, w.Header().Values("Vary"), "Origin")
+	})
+
+	t.Run("does not reflect a disallowed origin but still serves the request", func(t *testing.T) {
+		nextCalled = false
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/kotowaza", nil)
+		req.Header.Set("Origin", "https://evil.example.com")
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		assert.True(t, nextCalled)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+		assert.Contains(t, w.Header().Values("Vary"), "Origin")
+	})
+
+	t.Run("sets no allow-origin when the Origin header is absent", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/kotowaza", nil)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("answers a preflight from an allowed origin with 204 and CORS headers", func(t *testing.T) {
+		nextCalled = false
+		req := httptest.NewRequest(http.MethodOptions, "/api/v1/chat", nil)
+		req.Header.Set("Origin", "http://localhost:3000")
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		assert.False(t, nextCalled)
+		assert.Equal(t, http.StatusNoContent, w.Code)
+		assert.Equal(t, "http://localhost:3000", w.Header().Get("Access-Control-Allow-Origin"))
+		assert.Equal(t, "GET, POST, OPTIONS", w.Header().Get("Access-Control-Allow-Methods"))
+		assert.Contains(t, w.Header().Get("Access-Control-Allow-Headers"), "Content-Type")
+	})
+
+	t.Run("answers a preflight from a disallowed origin with 204 and no allow-origin", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodOptions, "/api/v1/chat", nil)
+		req.Header.Set("Origin", "https://evil.example.com")
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNoContent, w.Code)
+		assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+	})
+}

--- a/api/internal/service/chat_service.go
+++ b/api/internal/service/chat_service.go
@@ -79,6 +79,10 @@ func (s *ChatService) Chat(ctx context.Context, req ChatRequest) (*ChatResponse,
 		}
 	}
 
+	if req.KotowazaID == uuid.Nil {
+		return nil, fmt.Errorf("%w: kotowaza_id must not be zero value", ErrValidation)
+	}
+
 	k, err := s.repo.GetByID(ctx, req.KotowazaID)
 	if err != nil {
 		return nil, fmt.Errorf("get kotowaza for chat: %w", err)

--- a/api/internal/service/chat_service_test.go
+++ b/api/internal/service/chat_service_test.go
@@ -164,6 +164,16 @@ func TestChatService_Validation(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "message too long")
 	})
+
+	t.Run("rejects zero-value kotowaza id before hitting the repository", func(t *testing.T) {
+		_, err := svc.Chat(context.Background(), ChatRequest{
+			KotowazaID: uuid.Nil,
+			Messages:   []ChatMessage{{Role: "user", Content: "test"}},
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrValidation)
+		assert.Contains(t, err.Error(), "zero value")
+	})
 }
 
 func TestBuildSystemPrompt(t *testing.T) {


### PR DESCRIPTION
## 概要
セキュリティ・バグ・運用堅牢性に関する4件のIssueをまとめて対応。

Fixes #18, #17, #21, #20

## 変更内容

### #18 CORS Origin検証（security）
- 受信 `Origin` を環境変数 `CORS_ALLOWED_ORIGINS`（カンマ区切り許可リスト）と照合し、一致した場合のみ `Access-Control-Allow-Origin` に当該Originを返す方式へ変更。従来は単一Originを無検証で返していた。
- 許可外Originにはヘッダーを付与せず、ブラウザ側でブロックさせる。
- キャッシュ汚染を防ぐため `Vary: Origin` を常時付与。
- `CORS_ORIGIN`（単数）→ `CORS_ALLOWED_ORIGINS`（複数可）へ移行。`.env.example` 更新。
- 補足: 未設定時のみ `http://localhost:3000` を開発用フォールバックとして使用（本番は環境変数で明示指定）。

### #17 ゼロ値UUIDチェック（bug）
- `ChatService.Chat` で `KotowazaID == uuid.Nil` の場合、DBクエリ前に `ErrValidation`（HTTP 400）で早期リターン。無意味なDBクエリを防止。

### #21 HTTPサーバータイムアウト（enhancement）
- `ReadTimeout=15s` / `WriteTimeout=90s` / `IdleTimeout=120s` を設定。
- `WriteTimeout` はLLMクライアントのタイムアウト（60s）を上回る90sとし、正常な低速レスポンスの切断を回避しつつFD枯渇を防止。

### #20 ヘルスチェックのDB ping（enhancement）
- Liveness（`GET /api/v1/health`）とReadiness（`GET /api/v1/health/ready`）を分離。
- Readinessは2秒タイムアウトでDBに ping し、失敗時は 503 を返す（LBが障害ノードへの振り分けを停止できる）。
- pingの生エラーはサーバーログに記録し、公開エンドポイントには汎用メッセージのみ返す（接続情報の漏洩防止）。

## テスト
- `cors_test.go`（新規）: 許可/不許可Origin、プリフライト、Origin欠落、Vary付与を検証。
- `health_handler_test.go`: Live 200、Ready 200/503、エラー非漏洩を検証。
- `chat_service_test.go`: ゼロ値UUID拒否を追加。
- ローカル検証: `go build` / `go test -race` 全パス、`golangci-lint`（CI相当 v1.64.8）クリーン、`gofumpt` 整形済み。

## 影響範囲
- `CORS_ORIGIN` を使用している環境は `CORS_ALLOWED_ORIGINS` への切り替えが必要（`.env.example` 参照）。
- LB/監視のヘルスチェックはDB状態を含めたい場合 `/api/v1/health/ready` を参照（従来の `/api/v1/health` はプロセス生存のみ）。README更新済み。