### PR TITLE
ci: checkout v7 / setup-go v6 へ更新（Node 20 deprecation）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     name: API (Go)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.25"
       - name: Install tools
@@ -30,7 +30,7 @@ jobs:
     name: Web (Next.js)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v4
         with:
           node-version: "22"


### PR DESCRIPTION
checkout@v4 と setup-go@v5 は Node 20 ランタイム（CI に非推奨警告が出ていた）。actionlint パス済み。